### PR TITLE
Don't quit modifySeaMonkeyPage if the button is not visible

### DIFF
--- a/source/content/frame-script.js
+++ b/source/content/frame-script.js
@@ -102,21 +102,11 @@ var amoBr = {
   /* Modify SeaMonkey add-on page */
   modifySeaMonkeyPage: function() {
     var buttons = content.document.querySelectorAll('p.install-button a.button.add.concealed, p.install-button a.button.contrib.go.concealed');
-    var button;
-    
-    for (var i=0; i<buttons.length; i++) {
-      var b = buttons[i];
-      
-      if (!this.isElementHidden(b)) {
-        // visible button
-        button = b;
-        break;
-      }
-    }
-    
-    if (!button) {
+    if (buttons.length == 0) {
       return;
     }
+    
+    var button = buttons[0];
     
     button = this.removeEventsFromElem(button);
     button.classList.remove('concealed');


### PR DESCRIPTION
I don't know how the structure of the old AMO page was set up, but on the new one, the button that matches the selector in the script is actually hidden and not visible.
