### PR TITLE
Remove all uses of innerHTML

### DIFF
--- a/source/content/frame-script.js
+++ b/source/content/frame-script.js
@@ -262,14 +262,22 @@ var amoBr = {
       infoElem.style.maxWidth = '400px';
     }
     
-    var par1 = amoBr.getString('checkForSMVersion_info',
-      ["<a style='color: #fff;' href='" + this.converterURL + "'>", "</a>"]);
+    var p1 = content.document.createElement('p');
+    p1.style.fontSize = "10pt";
+    p1.style.textAlign = "left";
+    p1.appendChild(content.document.createTextNode(amoBr.getString('checkForSMVersion_info')));
+    infoElem.appendChild(p1);
     
-    var par2 = amoBr.getString('convertAddon',
-      ["<a style='color: #fff;' href='" + convertLink + "'>", "</a>"]);
-    
-    infoElem.innerHTML = "<p style='font-size: 10pt; text-align: left'>" + par1 + "</p>"
-      + "<p style='font-size: 10pt; text-align: left'>" + par2 + "</p>";
+    var p2 = content.document.createElement('p');
+    p1.style.fontSize = "10pt";
+    p1.style.textAlign = "left";
+    var p2_linkNode = content.document.createElement('a');
+    p2_linkNode.style.color = "#fff";
+    p2_linkNode.href = convertLink;
+    p2_linkNode.appendChild(content.document.createTextNode(amoBr.getString('convertAddon_link')));
+    p2.appendChild(p2_linkNode);
+    p2.appendChild(content.document.createTextNode(amoBr.getString('convertAddon_note')));
+    infoElem.appendChild(p2);
     
     hugeButton.parentNode.appendChild(infoElem);
   },

--- a/source/content/frame-script.js
+++ b/source/content/frame-script.js
@@ -269,14 +269,14 @@ var amoBr = {
     infoElem.appendChild(p1);
     
     var p2 = content.document.createElement('p');
-    p1.style.fontSize = "10pt";
-    p1.style.textAlign = "left";
+    p2.style.fontSize = "10pt";
+    p2.style.textAlign = "left";
     var p2_linkNode = content.document.createElement('a');
     p2_linkNode.style.color = "#fff";
     p2_linkNode.href = convertLink;
     p2_linkNode.appendChild(content.document.createTextNode(amoBr.getString('convertAddon_link')));
     p2.appendChild(p2_linkNode);
-    p2.appendChild(content.document.createTextNode(amoBr.getString('convertAddon_note')));
+    p2.appendChild(content.document.createTextNode(' - ' + amoBr.getString('convertAddon_note')));
     infoElem.appendChild(p2);
     
     hugeButton.parentNode.appendChild(infoElem);
@@ -299,7 +299,13 @@ var amoBr = {
       infoElem.style.maxWidth = '400px';
     }
     
-    infoElem.innerHTML = "<p style='font-size: 10pt; text-align: left; color: lawngreen'>" + amoBr.getString('FxAddOnIsCompatible') + "</p>";
+    var p = content.document.createElement('p');
+    p.style.fontSize = '10pt';
+    p.style.textAlign = 'left';
+    p.style.color = 'lawngreen';
+    p.appendChild(content.document.createTextNode(amoBr.getString('FxAddOnIsCompatible')));
+    
+    infoElem.appendChild(p);
     
     hugeButton.parentNode.appendChild(infoElem);
   },
@@ -328,15 +334,38 @@ var amoBr = {
     
     var addonData = this.getAddonData();
     if (this.strictAddOns.indexOf(addonData.addonId) < 0) {
-      infoElem.innerHTML = amoBr.getString('TbInfo',
-                ["<a style='color: #fff;' href='" + SMLink + "'><b>", "</b></a>",
-                 "<a style='color: #fff;' href='" + converterLink + "'>", "</a>"]) + '<br><br>'
-              + amoBr.getString('convertAddon',
-                ["<a style='color: #fff;' href='" + convertLink + "'>", "</a>"]);
-  
+	  var linkNode1 = content.document.createElement('a');
+	  linkNode1.style.color = "#fff";
+	  linkNode1.style.fontWeight = "bold";
+	  linkNode1.style.display = "block";
+	  linkNode1.href = SMLink;
+      linkNode1.appendChild(content.document.createTextNode(amoBr.getString('checkForSMVersion')));
+      infoElem.appendChild(linkNode1);
+	  
+	  var p1 = content.document.createElement('p');
+      p1.style.fontSize = "10pt";
+      p1.style.textAlign = "left";
+      p1.appendChild(content.document.createTextNode(amoBr.getString('TbInfo')));
+      infoElem.appendChild(p1);
+		
+      var p2 = content.document.createElement('p');
+      p2.style.fontSize = "10pt";
+      p2.style.textAlign = "left";
+      var p2_linkNode = content.document.createElement('a');
+      p2_linkNode.style.color = "#fff";
+      p2_linkNode.href = convertLink;
+      p2_linkNode.appendChild(content.document.createTextNode(amoBr.getString('convertAddon_link')));
+      p2.appendChild(p2_linkNode);
+      p2.appendChild(content.document.createTextNode(' - ' + amoBr.getString('convertAddon_note')));
+      infoElem.appendChild(p2);
     } else {
-      infoElem.innerHTML = amoBr.getString('SmVersionExists',
-                ["<a style='color: #fff;' href='" + SMLink + "'><b>", "</b></a>"]);
+      var linkNode1 = content.document.createElement('a');
+	  linkNode1.style.color = "#fff";
+	  linkNode1.style.fontWeight = "bold";
+	  linkNode1.style.display = "block";
+	  linkNode1.href = SMLink;
+      linkNode1.appendChild(content.document.createTextNode(amoBr.getString('checkForSMVersion')));
+      infoElem.appendChild(linkNode1);
     }
     
     shell.appendChild(infoElem);

--- a/source/content/frame-script.js
+++ b/source/content/frame-script.js
@@ -146,31 +146,31 @@ var amoBr = {
     if (addonData.isCompatible) {
       // add-on is compatible, only maxVersion is too low
       var compatibleByDefault = (Services.vc.compare(addonData.maxVersion, '2.1') >= 0);
-	  
-	  var span1 = content.document.createTextNode("span");
+      
+      var span1 = content.document.createTextNode("span");
       
       if (compatibleByDefault) {
         var info = amoBr.getString('maxSupportedVer', addonData.maxVersion) + ' '
         + amoBr.getString('maxSupportedVer_workFine');
-	  
-		infoElem.appendChild(content.document.createTextNode(info));
+      
+        infoElem.appendChild(content.document.createTextNode(info));
       
       } else {
         // very old extension - needs conversion
         var link = this.converterURL + "?url=" + encodeURIComponent(content.location.href);
         
         var info = amoBr.getString('maxSupportedVer', addonData.maxVersion) + ' '
-        + amoBr.getString('maxSupportedVer_needsConversion');
-		
-		infoElem.appendChild(content.document.createTextNode(info));
-		
-		var linktext = amoBr.getString('maxSupportedVer_needsConversion_link');
-		
-		var linkNode = content.document.createElement("a");
-		linkNode.style.color = "#fff";
-		linkNode.href = link;
-		infoElem.appendChild(linkNode);
-		linkNode.appendChild(content.document.createTextNode(linktext));
+        + amoBr.getString('maxSupportedVer_needsConversion') + ' ';
+        
+        infoElem.appendChild(content.document.createTextNode(info));
+        
+        var linktext = amoBr.getString('maxSupportedVer_needsConversion_link');
+        
+        var linkNode = content.document.createElement("a");
+        linkNode.style.color = "#fff";
+        linkNode.href = link;
+        infoElem.appendChild(linkNode);
+        linkNode.appendChild(content.document.createTextNode(linktext));
       }
       
       infoElem.style.color = 'lawngreen';
@@ -187,17 +187,27 @@ var amoBr = {
         info += amoBr.getString('maxSupportedVer_strictForced');
       
       } else {
-        var tagStart = "<a style='color: #fff;' href='" + link + "' style='font-weight: bold; color: darkred; text-decoration: underline;'>";
-        var tagEnd = "</a>";
-        info += amoBr.getString('maxSupportedVer_strict', [tagStart, tagEnd]);
+        info += amoBr.getString('maxSupportedVer_strict') + ' ';
       }
       
       // grey button:
       button.style.background = '';
       button.classList.add('concealed');
       
-      infoElem.innerHTML = info;
+      infoElem.appendChild(content.document.createTextNode(info));
       infoElem.style.color = 'red';
+      
+      if (this.strictAddOns.indexOf(addonData.addonId) < 0) {
+        var linktext = amoBr.getString('maxSupportedVer_strict_link');
+        
+        var linkNode = content.document.createElement("a");
+        linkNode.style.fontWeight = "bold";
+        linkNode.style.color = "darkred";
+        linkNode.style.textDecoration = "underline";
+        linkNode.href = link;
+        infoElem.appendChild(linkNode);
+        linkNode.appendChild(content.document.createTextNode(linktext));
+      }
     }
   },
   

--- a/source/content/frame-script.js
+++ b/source/content/frame-script.js
@@ -142,25 +142,37 @@ var amoBr = {
     }
     
     var addonData = this.getAddonData();
-    var info = "";
     
     if (addonData.isCompatible) {
       // add-on is compatible, only maxVersion is too low
       var compatibleByDefault = (Services.vc.compare(addonData.maxVersion, '2.1') >= 0);
+	  
+	  var span1 = content.document.createTextNode("span");
       
       if (compatibleByDefault) {
-        info = amoBr.getString('maxSupportedVer', addonData.maxVersion) + ' '
-      + amoBr.getString('maxSupportedVer_workFine');
+        var info = amoBr.getString('maxSupportedVer', addonData.maxVersion) + ' '
+        + amoBr.getString('maxSupportedVer_workFine');
+	  
+		infoElem.appendChild(content.document.createTextNode(info));
       
       } else {
         // very old extension - needs conversion
         var link = this.converterURL + "?url=" + encodeURIComponent(content.location.href);
         
-        info = amoBr.getString('maxSupportedVer', addonData.maxVersion) + ' '
-        + amoBr.getString('maxSupportedVer_needsConversion', ["<a style='color: #fff;' href='" + link + "'>", "</a>"]);
+        var info = amoBr.getString('maxSupportedVer', addonData.maxVersion) + ' '
+        + amoBr.getString('maxSupportedVer_needsConversion');
+		
+		infoElem.appendChild(content.document.createTextNode(info));
+		
+		var linktext = amoBr.getString('maxSupportedVer_needsConversion_link');
+		
+		var linkNode = content.document.createElement("a");
+		linkNode.style.color = "#fff";
+		linkNode.href = link;
+		infoElem.appendChild(linkNode);
+		linkNode.appendChild(content.document.createTextNode(linktext));
       }
       
-      infoElem.innerHTML = info;
       infoElem.style.color = 'lawngreen';
       
     } else {

--- a/source/locale/en-GB/global.properties
+++ b/source/locale/en-GB/global.properties
@@ -2,7 +2,9 @@ maxSupportedVer=Maximum officially supported SeaMonkey version for this add-on i
 
 maxSupportedVer_workFine=However, it is likely it will work fine also in newer SeaMonkey versions.
 
-maxSupportedVer_needsConversion=Most probably it will not install but you may try running it through the Add-on Converter. %SClick here%S to convert this add-on.
+maxSupportedVer_needsConversion=Most probably it will not install but you may try running it through the Add-on Converter.
+
+maxSupportedVer_needsConversion_link=Click here to convert this add-on.
 
 # %S are placeholders for opening and closing link tags
 maxSupportedVer_strict=It will probably not install because the author has opted for strict version compatibility check. You may try using the Add-on Converter to increase <em>maxVersion</em> and see if the add-on will work. %SClick here%S to increase <em>maxVersion</em> with the Converter.

--- a/source/locale/en-GB/global.properties
+++ b/source/locale/en-GB/global.properties
@@ -19,7 +19,7 @@ checkForSMVersion=Check if SeaMonkey version is available
 checkForSMVersion_info=If button "Add to SeaMonkey" does not appear after checking for SeaMonkey version, it means SeaMonkey is not officially supported. In this case you may try using the Add-on Converter. Warning: not all converted add-ons will work properly in SeaMonkey!
 
 convertAddon_link=Convert this add-on here
-convertAddon_note= - use only if no SeaMonkey version exists.
+convertAddon_note=use only if no SeaMonkey version exists.
 
 officialStatus=Official Status:
 
@@ -29,7 +29,7 @@ addTOSM=Add to SeaMonkey
 
 FxAddOnIsCompatible=Official SeaMonkey support is not offered by this add-on, however it should work fine. Feel free to install it!
 
-TbInfo=%SCheck if SeaMonkey version is available.%S If no SeaMonkey version exists you will be redirected back to this page &ndash; in that case you may try using the %SAdd-on Converter%S. Warning: not all converted add-ons will work properly in SeaMonkey!
+TbInfo=If no SeaMonkey version exists you will be redirected back to this page - in that case you may try using the Add-on Converter. Warning: not all converted add-ons will work properly in SeaMonkey!
 
 SmVersionExists=%SSeaMonkey version of this add-on exists!%S
 

--- a/source/locale/en-GB/global.properties
+++ b/source/locale/en-GB/global.properties
@@ -7,7 +7,9 @@ maxSupportedVer_needsConversion=Most probably it will not install but you may tr
 maxSupportedVer_needsConversion_link=Click here to convert this add-on.
 
 # %S are placeholders for opening and closing link tags
-maxSupportedVer_strict=It will probably not install because the author has opted for strict version compatibility check. You may try using the Add-on Converter to increase <em>maxVersion</em> and see if the add-on will work. %SClick here%S to increase <em>maxVersion</em> with the Converter.
+maxSupportedVer_strict=It will probably not install because the author has opted for strict version compatibility check. You may try using the Add-on Converter to increase maxVersion and see if the add-on will work.
+
+maxSupportedVer_strict_link=Click here to increase maxVersion with the Converter.
 
 maxSupportedVer_strictForced=It will run properly only under supported SeaMonkey versions. You may try contacting the author and ask if a version for your SeaMonkey installation is available.
 

--- a/source/locale/en-GB/global.properties
+++ b/source/locale/en-GB/global.properties
@@ -16,9 +16,10 @@ maxSupportedVer_strictForced=It will run properly only under supported SeaMonkey
 
 checkForSMVersion=Check if SeaMonkey version is available
 
-checkForSMVersion_info=If button <em>Add to SeaMonkey</em> does not appear after checking for SeaMonkey version, it means SeaMonkey is not officially supported. In this case you may try using the %SAdd-on Converter%S. Warning: not all converted add-ons will work properly in SeaMonkey!
+checkForSMVersion_info=If button "Add to SeaMonkey" does not appear after checking for SeaMonkey version, it means SeaMonkey is not officially supported. In this case you may try using the Add-on Converter. Warning: not all converted add-ons will work properly in SeaMonkey!
 
-convertAddon=%SConvert this add-on here%S &ndash; use only if no SeaMonkey version exists.
+convertAddon_link=Convert this add-on here
+convertAddon_note= - use only if no SeaMonkey version exists.
 
 officialStatus=Official Status:
 


### PR DESCRIPTION
Regarding bug 1224520 on bugzilla (https://bugzilla.mozilla.org/show_bug.cgi?id=1224520).

Here's a version of the add-on that doesn't use innerHTML at all. Maybe this will pass AMO inspection? If not, there's probably no reason to use this version of the code.

I took out links to "Add-on Converter" in the middle of sentences, because that would have required me to make more nodes, which means more lines of code.
