### PR TITLE
Various fixes

### DIFF
--- a/source/content/frame-script.js
+++ b/source/content/frame-script.js
@@ -679,8 +679,6 @@ var amoBr = {
       var action = item.querySelector('div.action');
       
       if (action) {
-        var convertLink = this.converterURL + "?url=" + encodeURIComponent(buttons[i].href);
-        
         var div = content.document.createElement('div');
         div.style.display = 'inline-block';
         div.style.maxWidth = '170px';
@@ -689,6 +687,20 @@ var amoBr = {
         div.style.textAlign = 'center';
         div.style.lineHeight = '1.4';
         div.innerHTML = amoBr.getString('notCompatible');
+      
+        var compat = item.querySelector('span.meta.compat');
+        if (compat) {
+          // Parse the compatibility string to figure out if this uses WebExtensions or not
+          var match = /Firefox.*- ?([0-9]+)/.exec(compat.innerText);
+          if (match) {
+            var maxVer = +match[1];
+            if (maxVer <= 56) {
+              var convertLink = this.converterURL + "?url=" + encodeURIComponent(buttons[i].href);
+              div.innerHTML = amoBr.getString('convertAddon',
+                ["<a href='" + convertLink + "' style='font-weight: bold'>", "</a>"]);
+            }
+          }
+        }
         
         action.textContent = '';
         action.appendChild(div);

--- a/source/content/frame-script.js
+++ b/source/content/frame-script.js
@@ -307,10 +307,10 @@ var amoBr = {
   modifyFirefoxPage: function() {
     
     // sometimes there may be 3 huge buttons, each for different OS
-    var hugeButtons = content.document.querySelectorAll('#addon p.install-button a.button.concealed.CTA');
+    var hugeButtons = content.document.querySelectorAll('#addon p.install-button a.button.CTA');
     
     if (hugeButtons.length == 0) {
-      hugeButtons = content.document.querySelectorAll('#contribution p.install-button a.button.concealed.CTA');
+      hugeButtons = content.document.querySelectorAll('#contribution p.install-button a.button.CTA');
     }
     
     if (hugeButtons.length > 0) {
@@ -345,7 +345,7 @@ var amoBr = {
     }
     
     // section with versions below
-    hugeButtons = content.document.querySelectorAll('section.primary.island.more-island p.install-button a.button.concealed.CTA');
+    hugeButtons = content.document.querySelectorAll('section.primary.island.more-island p.install-button a.button.CTA');
     
     for (var i=0; i<hugeButtons.length; i++) {
       var hugeButton = hugeButtons[i];
@@ -516,7 +516,7 @@ var amoBr = {
     for (var i=0; i<items.length; i++) {
       var item = items[i];
       var link = item.querySelector('h3 a');
-      var linkButtons = item.querySelectorAll('p.install-button a.button.concealed.CTA');
+      var linkButtons = item.querySelectorAll('p.install-button a.button.CTA');
       
       if (!link) {
         continue;
@@ -646,7 +646,7 @@ var amoBr = {
     
     // on Fx beta version page - replace huge "only with Firefox" buttons
     // with download buttons
-    var hugeButtons = content.document.querySelectorAll('div.listing div.items p.install-button a.button.download.concealed.CTA[data-realurl]');
+    var hugeButtons = content.document.querySelectorAll('div.listing div.items p.install-button a.button.download.CTA[data-realurl]');
     
     var modified = false;
     

--- a/source/content/frame-script.js
+++ b/source/content/frame-script.js
@@ -226,7 +226,7 @@ var amoBr = {
     var button = buttons[0];
     
     button = this.removeEventsFromElem(button);
-    button.classList.remove('concealed');
+    content.setTimeout(() => button.classList.remove('concealed'), 0);
     
     if (!button.classList.contains('caution')) {
       // fully reviewed (not preliminarily) add-on - add amber bg

--- a/source/content/frame-script.js
+++ b/source/content/frame-script.js
@@ -113,48 +113,52 @@ var amoBr = {
   
   /* Handle DOMContentLoaded event */
   handleEvent: function(e) {
-    if (e.target.defaultView.frameElement // ignore frames
-        || e.target.defaultView.location.href.indexOf('https://addons.mozilla.org/') != 0
-        || !content.document.body
-        ) {
-      return;
-    }
-    
-    //this.displayGrabbedLinks();
-    this.addStyleSheet();
-    var app = this.detectAppNameForPage();
-    
-    if (this.isAddonPage()) {
-      if (app == 'seamonkey') {
-        this.modifySeaMonkeyPage();
-        
-        var target = content.document.getElementById('page');
-        
-        if (target) {
-          this.addHoverCardObserver(target);
+    /* Delay until AMO scripts have run */
+    content.setTimeout(() => {
+      if (e.target.defaultView.frameElement // ignore frames
+          || e.target.defaultView.location.href.indexOf('https://addons.mozilla.org/') != 0
+          || !content.document.body
+          ) {
+        return;
+      }
+      
+      //this.displayGrabbedLinks();
+      this.addStyleSheet();
+      var app = this.detectAppNameForPage();
+      
+      if (this.isAddonPage()) {
+        if (app == 'seamonkey') {
+          this.modifySeaMonkeyPage();
+          
+          var target = content.document.getElementById('page');
+          
+          if (target) {
+            this.addHoverCardObserver(target);
+          }
+          
+        } else if (app == 'firefox') {
+          this.modifyFirefoxPage();
+          
+        } else if (app == 'thunderbird') {
+          this.modifyThunderbirdPage();
         }
         
-      } else if (app == 'firefox') {
-        this.modifyFirefoxPage();
+      } else {
+        // not add-on page
+        if (this.isListingPage()) {
+          this.modifyListing();
+          this.addSearchResultsObserver();
         
-      } else if (app == 'thunderbird') {
-        this.modifyThunderbirdPage();
+        } else if (this.isVersionsPage()) {
+          this.modifyVersionsPage();
+        }
+        
+        this.modifyCollectionListing();
+        this.modifyHoverCards();
       }
-      
-    } else {
-      // not add-on page
-      if (this.isListingPage()) {
-        this.modifyListing();
-        this.addSearchResultsObserver();
-      
-      } else if (this.isVersionsPage()) {
-        this.modifyVersionsPage();
-      }
-      
-      this.modifyCollectionListing();
-      this.modifyHoverCards();
-    }
+    }, 0);
   },
+
   
   /**
    * Watch for AMO scripts trying to replace download links with a link for downloading Fx.

--- a/source/content/frame-script.js
+++ b/source/content/frame-script.js
@@ -466,7 +466,7 @@ var amoBr = {
   /* Modify add-on listing page, e.g. "Up & Coming Extensions" */
   modifyListing: function() {
     // remove huge "only with Firefox" buttons
-    var hugeButtons = content.document.querySelectorAll('div.listing div.items p.install-button a.button.download.CTA[data-realurl]');
+    var hugeButtons = content.document.querySelectorAll('div.listing div.items p.install-button a.button.CTA');
     
     for (var i=0; i<hugeButtons.length; i++) {
       var item = hugeButtons[i];

--- a/source/content/frame-script.js
+++ b/source/content/frame-script.js
@@ -339,7 +339,9 @@ var amoBr = {
           this.FxPageAddOnIsCompatible(hugeButton, downloadAnywayButton);
           
         } else {
-          this.FxPageCheckForSMVersion(hugeButton);
+          if (content.document.querySelector('#addon .is-webextension') == null) {
+            this.FxPageCheckForSMVersion(hugeButton);
+          }
         }
       }
     }
@@ -468,10 +470,10 @@ var amoBr = {
     
     for (var i=0; i<hugeButtons.length; i++) {
       var item = hugeButtons[i];
-	  while (item && !item.classList.contains('item')) {
-		item = item.parentElement;
-	  }
-	  if (!item) continue;
+      while (item && !item.classList.contains('item')) {
+        item = item.parentElement;
+      }
+      if (!item) continue;
       
       var action = item.querySelector('div.action');
       
@@ -483,7 +485,9 @@ var amoBr = {
         div.style.fontSize = '8pt';
         div.style.textAlign = 'center';
         div.style.lineHeight = '1.4';
-        div.textContent = amoBr.getString('visitAddOn');
+        div.textContent = item.querySelector('.is-webextension')
+          ? amoBr.getString('notCompatible')
+          : amoBr.getString('visitAddOn');
         
         action.textContent = '';
         action.appendChild(div);

--- a/source/content/frame-script.js
+++ b/source/content/frame-script.js
@@ -463,11 +463,15 @@ var amoBr = {
 
   /* Modify add-on listing page, e.g. "Up & Coming Extensions" */
   modifyListing: function() {
-    var items = content.document.querySelectorAll('div.listing div.items > div.item.incompatible');
+    // remove huge "only with Firefox" buttons
+    var hugeButtons = content.document.querySelectorAll('div.listing div.items p.install-button a.button.download.CTA[data-realurl]');
     
-    for (var i=0; i<items.length; i++) {
-      var item = items[i];
-      item.classList.remove('incompatible');
+    for (var i=0; i<hugeButtons.length; i++) {
+      var item = hugeButtons[i];
+	  while (item && !item.classList.contains('item')) {
+		item = item.parentElement;
+	  }
+	  if (!item) continue;
       
       var action = item.querySelector('div.action');
       

--- a/source/content/style.css
+++ b/source/content/style.css
@@ -74,6 +74,6 @@ section.primary.island.more-island .button.not-available {
 }
 
 /* WebExtensions not compatible with SeaMonkey yet */
-div a.is-webextension, span.featured {
+div a.is-webextension {
     background-color: #930;
 }

--- a/source/content/style.css
+++ b/source/content/style.css
@@ -72,3 +72,8 @@ section.primary.island.more-island .button.not-available {
 .button.caution.concealed, .button.disabled, button[disabled] {
     pointer-events: auto !important;
 }
+
+/* WebExtensions not compatible with SeaMonkey yet */
+div a.is-webextension, span.featured {
+    background-color: #930;
+}

--- a/source/locale/en-GB/global.properties
+++ b/source/locale/en-GB/global.properties
@@ -30,4 +30,6 @@ SmVersionExists=%SSeaMonkey version of this add-on exists!%S
 
 visitAddOn=Visit add-on page for SeaMonkey compatibility information.
 
+notCompatible=This add-on is not compatible with SeaMonkey.
+
 download=Download

--- a/source/locale/en-GB/global.properties
+++ b/source/locale/en-GB/global.properties
@@ -16,6 +16,8 @@ checkForSMVersion_info=If button <em>Add to SeaMonkey</em> does not appear after
 
 convertAddon=%SConvert this add-on here%S &ndash; use only if no SeaMonkey version exists.
 
+webExtensions_info=This add-on is built with WebExtensions, which are not supported in SeaMonkey. You might want to check %Sprevious versions%S of this add-on to see if any of them are compatible with SeaMonkey.
+
 officialStatus=Official Status:
 
 


### PR DESCRIPTION
There might be other things that this doesn't fix.

* DOMContentLoaded handler defers execution with a setTimeout so the Mozilla scripts can run first
* CSS selector fixed for "Only with Firefox" buttons
* Search results page (modifyListing) fix
* Detect WebExtensions and:
  * Don't offer to convert them
  * Provide a link to the SeaMonkey versions page for that add-on (try it with: https://addons.mozilla.org/firefox/addon/twitter-app)